### PR TITLE
INSTALAR.command: detect the Epic install path (no space)

### DIFF
--- a/INSTALAR.command
+++ b/INSTALAR.command
@@ -108,7 +108,9 @@ for c in \
   "$HOME/GOG Games/Cyberpunk 2077" \
   "/Applications/Cyberpunk 2077" \
   "/Users/Shared/Epic Games/Cyberpunk 2077" \
+  "/Users/Shared/Epic Games/Cyberpunk2077" \
   "$HOME/Library/Application Support/Epic/Cyberpunk 2077" \
+  "$HOME/Library/Application Support/Epic/Cyberpunk2077" \
   "$(cd "$HERE/.." 2>/dev/null && pwd)/Cyberpunk 2077" \
   "$(cd "$HERE/../.." 2>/dev/null && pwd)" ; do
   if is_game "$c"; then GAME="$c"; break; fi


### PR DESCRIPTION
## The problem

The game-folder auto-detect list in `INSTALAR.command` spells both Epic candidates with a space:

```sh
"/Users/Shared/Epic Games/Cyberpunk 2077" \
"$HOME/Library/Application Support/Epic/Cyberpunk 2077" \
```

Epic Games Launcher installs the game to **`Cyberpunk2077`** — no space. So an Epic copy is never matched by `is_game`, detection falls through the whole list, and the user lands in the "drag the folder here" fallback even though the game is sitting in one of the paths already being checked.

Steam and GOG both use the spaced `Cyberpunk 2077`, which is probably how the Epic entries inherited that spelling.

## The fix

Adds the no-space variants **alongside** the existing entries instead of replacing them. Steam/GOG detection is untouched, and if any Epic layout does use the spaced name it still matches. Two added lines, no behaviour change for anything that already worked.

## Verification

Tested against a real Epic install:

- `/Users/Shared/Epic Games/Cyberpunk2077`, bundle id `com.cdprojektred.cyberpunk.egs`, game version **2.3.1** (matches `SUPPORTED_VER`)
- macOS 26.6.2, Apple Silicon

Before: not detected, fallback prompt. After: resolved automatically on the first pass.

The full install then completed end to end on that Epic copy, including the two steps that matter most here:

```
[4b/6] load command verified present
[5c/6] launch test PASSED (survived exec — AMFI/signature allow it to run)
[6/6] redscript cheats compiled (Settings > Cheats)
```

So the ad-hoc re-sign is not blocked by AMFI on the Epic build either. That is a single data point on one machine, not a claim that Epic is fully supported — this PR only changes path detection and makes no support claim beyond it.